### PR TITLE
Master to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: uv
     directory: /
     schedule:

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   analyze:
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     - cron: '44 3 * * 3'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This pull request updates several GitHub workflow configuration files to reflect a branch naming change from `master` to `main`, and adds support for automated dependency updates for GitHub Actions. These changes help ensure consistency across CI/CD pipelines and improve automated maintenance.

**Branch name updates:**

* Updated all workflow triggers in `.github/workflows/analyze.yml`, `.github/workflows/codeql.yml`, and `.github/workflows/test.yml` to use the `main` branch instead of `master`. This affects both `push` and `pull_request` events, ensuring workflows run on the correct branch. [[1]](diffhunk://#diff-14aff60dd13e87ce7794535902a1244426e49d1ce5e921a35eb41650b8e7796bL4-R4) [[2]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L16-R19) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L5-R8)

**Automated dependency updates:**

* Added a new configuration in `.github/dependabot.yml` to enable weekly automated updates for GitHub Actions dependencies, improving security and reliability of workflow actions.